### PR TITLE
Test with Ruby 3.2 on CI

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -11,11 +11,10 @@ permissions:
 
 jobs:
   test:
-
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: ['3.1', head]
+        ruby-version: ['3.1', '3.2', head]
 
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
`.ruby-version` of base branch specify ruby version as 3.2 & current ruby head is 3.3.0 dev, so we don't test on Ruby 3.2! ;)